### PR TITLE
fix(ci): improve Playwright browser installation reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
         run: |
           ./clipper-backend &
           echo $! > backend.pid
-          
+
           # Wait for backend to be ready
           for i in {1..30}; do
             if curl -f http://localhost:8080/api/v1/health 2>/dev/null; then
@@ -343,10 +343,9 @@ jobs:
           cd frontend
           npm ci
 
-      - name: Install Playwright browsers
-        run: |
-          cd frontend
-          npx playwright install --with-deps chromium
+      - name: Install Playwright Browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
 
       - name: Run E2E tests
         env:


### PR DESCRIPTION
Follow-up to #410 to fix potential issues with Playwright browser installation in the E2E workflow.

Changes:
- Use `working-directory` instead of `cd` for Playwright install step
- More idiomatic GitHub Actions syntax for better reliability

This ensures Playwright browsers are installed correctly before running E2E tests.